### PR TITLE
- Add rapid api service and test projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+# Ignore bin and obj folders
+**/bin/
+**/obj/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (Console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/geji-rapid-api-service-test/bin/Debug/net8.0/geji-rapid-api-service-test.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/geji-rapid-api-service-test",
+      "stopAtEntry": false,
+      "console": "internalConsole",
+      "internalConsoleOptions": "openOnSessionStart",
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/geji-rapid-api-service-test/geji-rapid-api-service-test.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/geji-rapid-api-service-test/Program.cs
+++ b/geji-rapid-api-service-test/Program.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using RapidApiService.Services;
+
+namespace RapidApiServiceTest
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var apiHost = "real-time-amazon-data.p.rapidapi.com"; 
+            var apiKey = "70291374f2msh838354b882d33c5p143097jsnfaf33230915d"; 
+            //TODO, move to cloud provider based app config service
+
+            var rapidApiService = new RapidApiService.Services.RapidApiService(apiHost, apiKey);
+
+            try
+            {
+                // Replace with your actual search term
+                string query = "phone";
+
+                var data = await rapidApiService.GetProductSearchEndpointDataAsync(query);
+                Console.WriteLine(data.ToString());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred: {ex.Message}");
+            }
+        }
+    }
+}

--- a/geji-rapid-api-service-test/geji-rapid-api-service-test.csproj
+++ b/geji-rapid-api-service-test/geji-rapid-api-service-test.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\geji-rapid-api-service\geji-rapid-api-service.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>geji_rapid_api_service_test</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/geji-rapid-api-service/Interfaces/IRapidApiService.cs
+++ b/geji-rapid-api-service/Interfaces/IRapidApiService.cs
@@ -1,0 +1,13 @@
+
+
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace RapidApiService.Interfaces
+{
+    public interface IRapidApiService
+    {
+        Task<JObject> GetEndpointDataAsync(string endpointUrl);
+        Task<JObject> GetProductSearchEndpointDataAsync(string query);
+    }
+}

--- a/geji-rapid-api-service/Services/RapidApiService.cs
+++ b/geji-rapid-api-service/Services/RapidApiService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using RapidApiService.Interfaces;
+
+namespace RapidApiService.Services
+{
+
+    /// <summary>  
+    /// Rapid api service class.
+    /// For usage, look at the Program.cs file in the geji-rapi-api-service-test project.
+    /// </summary>
+    public class RapidApiService: IRapidApiService
+    {
+        private readonly HttpClient _httpClient;
+        
+        public RapidApiService(string rapidApiHost, string rapidApiKey)
+        {
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("x-rapidapi-key", rapidApiKey); 
+            _httpClient.DefaultRequestHeaders.Add("x-rapidapi-host", rapidApiHost); 
+        }
+
+        public async Task<JObject> GetEndpointDataAsync(string endpointUrl)
+        {
+            var response = await _httpClient.GetAsync(endpointUrl);
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(content);
+        }
+
+        public async Task<JObject> GetProductSearchEndpointDataAsync(string query)
+        {
+            string queryEndpoint = string.Format($"https://real-time-amazon-data.p.rapidapi.com/search?query={query}");
+            var response = await _httpClient.GetAsync(queryEndpoint);
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(content);
+        }
+
+        //TODO: Add more methods for other endpoints from here
+        //https://rapidapi.com/letscrape-6bRBa3QguO5/api/real-time-amazon-data/playground/apiendpoint_e8779502-64aa-4a06-ad7e-84a1ad1bcd67
+        
+    }
+}

--- a/geji-rapid-api-service/geji-rapid-api-service.csproj
+++ b/geji-rapid-api-service/geji-rapid-api-service.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>geji_rapid_api_service</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/geji.sln
+++ b/geji.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "geji-rapid-api-service", "geji-rapid-api-service\geji-rapid-api-service.csproj", "{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "geji-rapid-api-service-test", "geji-rapid-api-service-test\geji-rapid-api-service-test.csproj", "{F663FEC7-B3FF-4CF3-BC70-FBE62106303A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F663FEC7-B3FF-4CF3-BC70-FBE62106303A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F663FEC7-B3FF-4CF3-BC70-FBE62106303A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F663FEC7-B3FF-4CF3-BC70-FBE62106303A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F663FEC7-B3FF-4CF3-BC70-FBE62106303A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/geji.sln
+++ b/geji.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "geji-rapid-api-service", "geji-rapid-api-service\geji-rapid-api-service.csproj", "{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6A3B06C-DDC6-4BE2-933B-BC6DAE743DDB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5946CE9B-E39B-48F7-B97E-355A86B063C5}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This pull request adds two new projects, geji-rapid-api-service and geji-rapid-api-service-test, to the repository. The geji-rapid-api-service project includes a new interface, IRapidApiService, and its implementation. The geji-rapid-api-service-test project includes a test program that demonstrates the usage of the RapidApiService class. Additionally, the pull request includes the necessary configuration files for building and debugging the projects in Visual Studio Code. Currently only makes use of (Amazon endpoints) 